### PR TITLE
BUG FIX: Remove source code reliance on precompiled header

### DIFF
--- a/DSLCalendarView/DSLCalendarDayCalloutView.h
+++ b/DSLCalendarView/DSLCalendarDayCalloutView.h
@@ -29,6 +29,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <UIKit/UIKit.h>
 
 @interface DSLCalendarDayCalloutView : UIView
 

--- a/DSLCalendarView/DSLCalendarDayView.h
+++ b/DSLCalendarView/DSLCalendarDayView.h
@@ -29,6 +29,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <UIKit/UIKit.h>
 
 enum {
     DSLCalendarDayViewNotSelected = 0,

--- a/DSLCalendarView/DSLCalendarMonthSelectorView.h
+++ b/DSLCalendarView/DSLCalendarMonthSelectorView.h
@@ -29,6 +29,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <UIKit/UIKit.h>
 
 @interface DSLCalendarMonthSelectorView : UIView
 

--- a/DSLCalendarView/DSLCalendarMonthView.h
+++ b/DSLCalendarView/DSLCalendarMonthView.h
@@ -29,6 +29,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <UIKit/UIKit.h>
 
 @class DSLCalendarDayView;
 @class DSLCalendarRange;

--- a/DSLCalendarView/DSLCalendarRange.h
+++ b/DSLCalendarView/DSLCalendarRange.h
@@ -29,6 +29,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <UIKit/UIKit.h>
 
 @interface DSLCalendarRange : NSObject
 

--- a/DSLCalendarView/NSDate+DSLCalendarView.h
+++ b/DSLCalendarView/NSDate+DSLCalendarView.h
@@ -6,6 +6,7 @@
 //  Copyright 2012 Pete Callaway. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
 
 @interface NSDate (DSLCalendarView)
 


### PR DESCRIPTION
The `DSL...` files rely on being added to a project uses a `.pch` file. This pull request explicitly calls out the dependency on `UIKit` and makes it for developers adopting Xcode Modules to integrate the source into their app.
