### PR TITLE
BUG FIX: Casting NSInteger for use in format strings

### DIFF
--- a/DSLCalendarView/DSLCalendarDayCalloutView.m
+++ b/DSLCalendarView/DSLCalendarDayCalloutView.m
@@ -79,7 +79,7 @@
         [self insertSubview:self.imageView atIndex:0];
     }
     
-    self.titleLabel.text = [NSString stringWithFormat:@"%d", day.day];
+    self.titleLabel.text = [NSString stringWithFormat:@"%ld", (long)day.day];
 
     CGFloat const imagePadding = 15.0;
     CGRect frame = self.frame;

--- a/DSLCalendarView/DSLCalendarDayView.m
+++ b/DSLCalendarView/DSLCalendarDayView.m
@@ -71,7 +71,7 @@
     _calendar = [day calendar];
     _dayAsDate = [day date];
     _day = nil;
-    _labelText = [NSString stringWithFormat:@"%d", day.day];
+    _labelText = [NSString stringWithFormat:@"%ld", (long)day.day];
 }
 
 - (NSDateComponents*)day {

--- a/DSLCalendarView/DSLCalendarView.m
+++ b/DSLCalendarView/DSLCalendarView.m
@@ -195,7 +195,7 @@
 
 - (NSString*)monthViewKeyForMonth:(NSDateComponents*)month {
     month = [month.calendar components:NSYearCalendarUnit | NSMonthCalendarUnit fromDate:month.date];
-    return [NSString stringWithFormat:@"%d.%d", month.year, month.month];
+    return [NSString stringWithFormat:@"%ld.%ld", (long)month.year, (long)month.month];
 }
 
 - (DSLCalendarMonthView*)cachedOrCreatedMonthViewForMonth:(NSDateComponents*)month {

--- a/Example/DSLCalendarViewExample/ViewController.m
+++ b/Example/DSLCalendarViewExample/ViewController.m
@@ -41,7 +41,7 @@
 
 - (void)calendarView:(DSLCalendarView *)calendarView didSelectRange:(DSLCalendarRange *)range {
     if (range != nil) {
-        NSLog( @"Selected %d/%d - %d/%d", range.startDay.day, range.startDay.month, range.endDay.day, range.endDay.month);
+        NSLog( @"Selected %ld/%ld - %ld/%ld", (long)range.startDay.day, (long)range.startDay.month, (long)range.endDay.day, (long)range.endDay.month);
     }
     else {
         NSLog( @"No selection" );


### PR DESCRIPTION
Library was last updated before 64-bit devices, and this pull request helps smooth out some of that transition by replacing code similar to:

 `@" ... %d ... ", (NSInteger)64`

...with the standard Xcode type it for me correction...

`@" ... %ld ... ", (long)(NSInteger)64`.
